### PR TITLE
Implements filtering for old ZKB mails

### DIFF
--- a/rooster.py
+++ b/rooster.py
@@ -224,6 +224,11 @@ async def killwatch():
             await asyncio.sleep(10)
             stream['package'] = None
         if stream['package']:
+            # Check the KM isn't old yet
+            kill_time = arrow.get(stream['package']['killmail']['killTime'], 'YYYY.MM.DD HH:mm:ss')
+            if kill_time < arrow.utcnow().shift(days=-2):
+                continue
+
             if 'alliance' in stream['package']['killmail']['victim']:
                 if stream['package']['killmail']['victim']['alliance']['id'] == ALLIANCE:
                     if stream['package']['zkb']['totalValue'] >= VALUE:


### PR DESCRIPTION
This is basically a safeguard to what happens when ZKB gets a new account with old killmails. Drops any killmail older than two days, which normally shouldn't ever happen, except when old data is new to zkb. 

closes #4 